### PR TITLE
Avoid Java 17 unfriendly log synchronization

### DIFF
--- a/src/main/java/Invokers/ApiClient.java
+++ b/src/main/java/Invokers/ApiClient.java
@@ -1200,8 +1200,10 @@ public class ApiClient {
 			Response response = call.execute();
 			responseCode = String.valueOf(response.code());
 			status = response.message();
-
-			logger.debug("Network Response :\n" + json.serialize(response.headers()));
+                        
+			if (logger.isDebugEnabled()) {
+				logger.debug("Network Response :\n" + json.serialize(response.headers()));
+			}
 
 			if(returnType == new TypeToken< Model.AccessTokenResponse >(){}.getType()) {
 				logger.debug("Response :\n" + response.peekBody(Long.MAX_VALUE).string());


### PR DESCRIPTION
The GSON serialization in logger.debug("Network Response :\n" + json.serialize(response.headers())); fails under Java 17 runtime, due to reflection access controls on the core JDK classes